### PR TITLE
Fix dependency installation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
           - .env
         volumes:
           - ./src:/src          # Mount the src directory for live updates
+          - ./poetry.lock:/poetry.lock # Mount these files to the container, so that we can can use `docker compose run poetry add ...` to add dependencies
+          - ./pyproject.toml:/pyproject.toml
           - ${MASKBENCH_DATASET_DIR}:/datasets  
           - ${MASKBENCH_OUTPUT_DIR}:/output
         tty: true               # Keep the container running interactively


### PR DESCRIPTION
If we want to add a new dependency (e.g. `numpy`) we can now do so using the following command `docker compose run --rm runner poetry add numpy`.
To remove a dependency type `docker compose run --rm runner poetry remove numpy`.

@zainabzafari How it works: When we run the above command, the poetry files within the docker container are updated, but the local files on our server are not updated. Therefore, I mounted the poetry.lock and pyproject.toml files into the docker container, so that when they are updated within the docker container, they are updated on our system as well.