### PR TITLE
Add Openpose script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
         build: .                # Build the image from the Dockerfile inside the current directory
         env_file: 
           - .env
+        depends_on:
+          - openpose
         volumes:
           - ./src:/src          # Mount the src directory for live updates
           - ./poetry.lock:/poetry.lock # Mount these files to the container, so that we can can use `docker compose run poetry add ...` to add dependencies
@@ -20,3 +22,21 @@ services:
                 - driver: nvidia
                   count: 1
                   capabilities: [ gpu ]
+
+    openpose:
+      image: ghcr.io/maskanyone/maskanyone/openpose:0.3.0
+      restart: on-failure
+      environment:
+        OPENPOSE_MODEL_DIR: "/workspace/openpose/models"
+      deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                count: 1
+                capabilities: [ gpu ]
+      devices:
+        - /dev/nvidia0:/dev/nvidia0
+        - /dev/nvidiactl:/dev/nvidiactl
+        - /dev/nvidia-uvm:/dev/nvidia-uvm
+        - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools

--- a/src/scripts/openpose.py
+++ b/src/scripts/openpose.py
@@ -1,0 +1,94 @@
+import argparse
+import os
+import tempfile
+import pickle
+import requests
+import cv2
+import json
+
+def draw_pose(frame, keypoints, confidence_threshold=0.1):
+    # keypoints: list of (x, y, confidence) tuples
+    # Example skeleton connections (OpenPose BODY_25 format)
+    skeleton = [
+        (1, 8), (1, 2), (1, 5), (2, 3), (3, 4), (5, 6), (6, 7), (8, 9),
+        (9, 10), (10, 11), (8, 12), (12, 13), (13, 14), (1, 0), (0, 15),
+        (15, 17), (0, 16), (16, 18), (14, 19), (19, 20),
+        (14, 21), (11, 22), (22, 23), (11, 24)
+        # (2, 17), (5, 18)
+    ]
+
+    for pair in skeleton:
+        part_from, part_to = pair
+        if keypoints[part_from][2] > confidence_threshold and keypoints[part_to][2] > confidence_threshold:
+            x1, y1 = int(keypoints[part_from][0]), int(keypoints[part_from][1])
+            x2, y2 = int(keypoints[part_to][0]), int(keypoints[part_to][1])
+            cv2.line(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+
+    for x, y, conf in keypoints:
+        if conf > confidence_threshold:
+            cv2.circle(frame, (int(x), int(y)), 3, (0, 0, 255), -1)
+
+def main():
+    parser = argparse.ArgumentParser(description="Run OpenPose on a video file.")
+    parser.add_argument("--video_path", type=str, required=True, help="Path to the input video file relative to /datasets.")
+    args = parser.parse_args()
+    
+    video_path = os.path.join("/datasets", args.video_path)
+    video_file_name = os.path.splitext(os.path.basename(video_path))[0]
+    out_dir = "/output"
+
+    openpose_url = "http://openpose:8000/openpose/estimate-pose-on-video"
+
+    data = {
+        'options': {
+            'model_pose': 'BODY_25',
+            'face': False,
+            'hand': False
+        }
+    }
+
+    print("Uploading video to OpenPose container and starting pose estimation...")
+    # Upload video to OpenPose container
+    with open(video_path, "rb") as f:
+        files = {"video": ("input.mp4", f, "video/mp4")}
+        options = { 'model_pose': 'BODY_25', 'face': False, 'hand': False }
+        data = {"options": json.dumps(options)}
+        response = requests.post(openpose_url, files=files, data=data)
+
+    if response.status_code != 200:
+        raise Exception(f"OpenPose container error: {response.status_code} {response.text}")
+
+    # Load pose data
+    pose_data = pickle.loads(response.content)  # Expecting {frame_idx: list of keypoints}
+
+    cap = cv2.VideoCapture(video_path)
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    output_path = os.path.join(out_dir, f"openpose_{video_file_name}.mp4")
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+
+    frame_idx = 0
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        if frame_idx < len(pose_data):
+            keypoints_list = pose_data[frame_idx]
+        else:
+            keypoints_list = []
+
+        draw_pose(frame, keypoints_list["pose_keypoints"])
+
+        writer.write(frame)
+        frame_idx += 1
+
+    cap.release()
+    writer.release()
+    print("Video saved to", output_path)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added an openpose script that takes as input a video and outputs a video that shows the skeleton overlayed on the original video. We are using the MaskAnyone OpenPose Image and make a HTTP request to that container, essentially uploading the video and getting the poses back. Thereafter, the poses are displayed on the video (which is a temporary and non-standardized solution for us in this script).

To execute it, use 
````
docker compose run --rm runner python3 scripts/openpose.py --video_path ted-talks/0137_curiosity_10s/0137_curiosity_chunk7.mp4
```

Currently it is not possible to specify different openpose models. This can be added in the real application. We could also check, whether we can reuse some of MaskAnyone's drawing logic to have a common output of YOLO, Mediapipe and OpenPose models that is visually the same (same colors etc.)