### PR TITLE
Fix: New files are not deletable and owned by root

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,5 +5,5 @@ MASKBENCH_WEIGHTS_DIR=<path to your weights directory>
 MASKBENCH_CONFIG_FILE=maskbench-config.yml # You can copy the maskbench-config.yml and use your own config file
 
 # Execution specific variables
-MASKBENCH_GPU_ID=1 # Set the GPU ID to use, e.g., 0, 1, 2, etc. If you want to use all GPUs, set it to "all".
+MASKBENCH_GPU_ID=0 # Set the GPU ID to use, e.g., 0, 1, 2, etc. If you want to use all GPUs, set it to "all".
 MASK_ANYONE_VERSION=0.3.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,6 @@ WORKDIR /src
 COPY src/ /src/
 
 # Default command when the container starts
-CMD ["python3", "main.py"]
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Initialize trap handlers
+cleanup() {
+  echo "Fixing permissions..."
+  chmod -R a+rw /output
+}
+
+handle_sigterm() {
+  kill -TERM "$child" 2>/dev/null
+  wait "$child"
+  cleanup
+  exit 0
+}
+
+handle_sigint() {
+  kill -INT "$child" 2>/dev/null
+  wait "$child"
+  cleanup
+  exit 0
+}
+
+# Set up signal handlers
+trap handle_sigterm SIGTERM
+trap handle_sigint SIGINT
+trap cleanup EXIT
+
+# Start the Python process in the background and get its PID
+python3 main.py &
+child=$!
+
+# Wait for the Python process to complete
+wait "$child"


### PR DESCRIPTION
Running the docker container with a specific user ID and group did not work and created multiple other problems (e.g. with YOLO configuration files).

I added an entrypoint script, which runs a cleanup function for all ways the application could end and makes all files in the output directory deletable. The cleanup function is executed no matter the reason why the application failed.

The service is started normally with `docker compose up`.

Please only create new files in the `/output` directory. Other directories are not covered by the cleanup function.