### PR TITLE
Fix: MaskAnyoneAPI returns multiple errors

### DIFF
--- a/src/models/maskanyone_api_pose_estimator.py
+++ b/src/models/maskanyone_api_pose_estimator.py
@@ -87,7 +87,8 @@ class MaskAnyoneApiPoseEstimator(PoseEstimator):
             fps=video_metadata.get("fps"),
             frame_width=video_metadata.get("width"),
             frame_height=video_metadata.get("height"),
-            frames=frame_results
+            frames=frame_results,
+            video_name=video_metadata.get("name")
         )
     
     def _get_config(self):

--- a/src/models/mediapipe_pose_estimator.py
+++ b/src/models/mediapipe_pose_estimator.py
@@ -99,7 +99,6 @@ class MediaPipePoseEstimator(PoseEstimator):
         self.detector = PoseLandmarker.create_from_options(self.options)
 
         cap, video_metadata = utils.get_video_metadata(video_path)
-        video_name = os.path.splitext(os.path.basename(video_path))[0]
         width = video_metadata.get("width")
         height = video_metadata.get("height")
         fps = video_metadata.get("fps")
@@ -141,7 +140,7 @@ class MediaPipePoseEstimator(PoseEstimator):
             frame_width=width,
             frame_height=height,
             frames=frame_results,
-            video_name=video_name,
+            video_name=video_metadata.get("name"),
         )
 
     def _execute_on_frame(self, frame, frame_number: int, fps: int):

--- a/src/models/open_pose_estimator.py
+++ b/src/models/open_pose_estimator.py
@@ -55,9 +55,8 @@ class OpenPoseEstimator(PoseEstimator):
             VideoPoseResult: A standardized result object containing the pose estimation results for the video.
         """
         pose_data, video_metadata = self._query_openpose_container(video_path)
-        video_name = os.path.splitext(os.path.basename(video_path))[0]
         video_pose_result = self._convert_to_video_pose_result(
-            pose_data, video_metadata, video_name
+            pose_data, video_metadata
         )
         return video_pose_result
 
@@ -89,7 +88,7 @@ class OpenPoseEstimator(PoseEstimator):
         return pose_data, video_metadata
 
     def _convert_to_video_pose_result(
-        self, pose_data, video_metadata: dict, video_name: str
+        self, pose_data, video_metadata: dict
     ) -> VideoPoseResult:
         frame_results = []
         for idx, frame in enumerate(pose_data):  # every frame
@@ -111,5 +110,5 @@ class OpenPoseEstimator(PoseEstimator):
             frame_width=video_metadata.get("width"),
             frame_height=video_metadata.get("height"),
             fps=video_metadata.get("fps"),
-            video_name=video_name
+            video_name=video_metadata.get("name")
         )

--- a/src/models/yolo_pose_estimator.py
+++ b/src/models/yolo_pose_estimator.py
@@ -67,7 +67,6 @@ class YoloPoseEstimator(PoseEstimator):
         """
 
         cap, video_metadata = utils.get_video_metadata(video_path)
-        video_name = os.path.splitext(os.path.basename(video_path))[0]
         cap.release()
 
         confidence = self.config.get("confidence_threshold", 0.85)
@@ -104,6 +103,6 @@ class YoloPoseEstimator(PoseEstimator):
             frame_width=video_metadata.get("width"),
             frame_height=video_metadata.get("height"),
             frames=frame_results,
-            video_name=video_name,
+            video_name=video_metadata.get("name"),
         )
         return video_result

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,30 +1,29 @@
+import os
 import cv2
 
 
-def get_video_metadata(video: str | cv2.VideoCapture) -> dict:
+def get_video_metadata(video_path: str) -> dict:
     """
     Get metadata of a video capture object.
 
     Args:
-        cap (str | cv2.VideoCapture): The path to the video or the video capture object.
+        cap (str): The path to the video.
 
     Returns:
-        dict: A dictionary containing the video's metadata such as width, height, fps, and duration.
+        dict: A dictionary containing the video's metadata such as width, height, fps, duration, and name.
     """
-    if isinstance(video, str):
-        cap = cv2.VideoCapture(video)
-    elif isinstance(video, cv2.VideoCapture):
-        cap = video
+    cap = cv2.VideoCapture(video_path)
 
     if not cap.isOpened():
         raise ValueError("Video capture is not opened.")
 
+    video_name = os.path.splitext(os.path.basename(video_path))[0]
     width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
     height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
     fps = cap.get(cv2.CAP_PROP_FPS)
     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     duration = frame_count / fps if fps > 0 else 0
 
-    metadata = {"width": width, "height": height, "fps": fps, "duration": duration}
+    metadata = {"width": width, "height": height, "fps": fps, "duration": duration, "name": video_name}
 
     return cap, metadata


### PR DESCRIPTION
@ShaddAhmed14 I started this branch, please continue working on it to fix some errors with MaskAnyoneAPI. Completed tasks are the ones I already solved.

- [x] We got an error that `video_name` was missing when creating the VideoPoseResult in MaskAnyoneAPI estimator. I set it correctly and also moved the extraction of the video name to a utils method.
- [x] When combining the files from the JSONs, there are `None` Keypoints created as well as `PersonPoseResults` that have `keypoints = None`. These result in an error when computing the metric. I don't know, whether these Nones are due to the way the JSONs are combined or if they stem from MaskAnyone itself. In case so, what do they mean? Please figure that out.

![image](https://github.com/user-attachments/assets/4978c3a2-0947-4010-a5a2-b43da3eff7b4)
![Bildschirmfoto 2025-06-25 um 18 15 53](https://github.com/user-attachments/assets/9aeb1781-d53b-48c6-8895-30269c721baf)

