### PR TITLE
Set correct scale of plots & ensure consistent order of pose estimators

### DIFF
--- a/config/raw-masked-experiment.yml
+++ b/config/raw-masked-experiment.yml
@@ -1,4 +1,6 @@
-checkpoint_name: None # comment out or set to "None" to run inference from scratch
+inference_checkpoint_name: None # comment out or set to "None" to run inference from scratch
+execute_evaluation: true        # set to false to skip calculating evaluation metrics and plotting
+execute_rendering: true         # set to false to skip rendering the videos
 
 dataset:
   name: RawMaskedExperiment

--- a/config/ted-kid.yml
+++ b/config/ted-kid.yml
@@ -7,10 +7,10 @@ dataset:
   module: datasets.ted_dataset
   class: TedDataset
   dataset_folder: /datasets/TED-kid/videos/raw
-  # dataset_folder: /datasets/raw-masked-experiment/videos/blurring
-  # dataset_folder: /datasets/raw-masked-experiment/videos/pixelation
-  # dataset_folder: /datasets/raw-masked-experiment/videos/contours
-  # dataset_folder: /datasets/raw-masked-experiment/videos/inpainting
+  # dataset_folder: /datasets/TED-kid/videos/blurring
+  # dataset_folder: /datasets/TED-kid/videos/pixelation
+  # dataset_folder: /datasets/TED-kid/videos/contours
+  # dataset_folder: /datasets/TED-kid/videos/inpainting
 
 
 pose_estimators:
@@ -66,10 +66,10 @@ pose_estimators:
     class: MaskAnyoneUiPoseEstimator  
     config:
       dataset_folder_path: /datasets/TED-kid/maskanyone_ui_mediapipe/raw
-      # dataset_folder_path: /datasets/raw-masked-experiment/maskanyone_ui_mediapipe/blurring
-      # dataset_folder_path: /datasets/raw-masked-experiment/maskanyone_ui_mediapipe/pixelation
-      # dataset_folder_path: /datasets/raw-masked-experiment/maskanyone_ui_mediapipe/contours
-      # dataset_folder_path: /datasets/raw-masked-experiment/maskanyone_ui_mediapipe/inpainting
+      # dataset_folder_path: /datasets/TED-kid/maskanyone_ui_mediapipe/blurring
+      # dataset_folder_path: /datasets/TED-kid/maskanyone_ui_mediapipe/pixelation
+      # dataset_folder_path: /datasets/TED-kid/maskanyone_ui_mediapipe/contours
+      # dataset_folder_path: /datasets/TED-kid/maskanyone_ui_mediapipe/inpainting
       overlay_strategy: mp_pose
       save_keypoints_in_coco_format: true
       confidence_threshold: 0
@@ -80,10 +80,10 @@ pose_estimators:
     class: MaskAnyoneUiPoseEstimator  
     config:
       dataset_folder_path: /datasets/TED-kid/maskanyone_ui_openpose/raw
-      # dataset_folder_path: /datasets/raw-masked-experiment/maskanyone_ui_openpose/blurring
-      # dataset_folder_path: /datasets/raw-masked-experiment/maskanyone_ui_openpose/pixelation
-      # dataset_folder_path: /datasets/raw-masked-experiment/maskanyone_ui_openpose/contours
-      # dataset_folder_path: /datasets/raw-masked-experiment/maskanyone_ui_openpose/inpainting
+      # dataset_folder_path: /datasets/TED-kid/maskanyone_ui_openpose/blurring
+      # dataset_folder_path: /datasets/TED-kid/maskanyone_ui_openpose/pixelation
+      # dataset_folder_path: /datasets/TED-kid/maskanyone_ui_openpose/contours
+      # dataset_folder_path: /datasets/TED-kid/maskanyone_ui_openpose/inpainting
       overlay_strategy: openpose_body25b
       save_keypoints_in_coco_format: true
       confidence_threshold: 0

--- a/config/ted-kid.yml
+++ b/config/ted-kid.yml
@@ -1,4 +1,6 @@
-checkpoint_name: None # comment out or set to "None" to run inference from scratch
+inference_checkpoint_name: None # comment out or set to "None" to run inference from scratch
+execute_evaluation: true        # set to false to skip calculating evaluation metrics and plotting
+execute_rendering: true         # set to false to skip rendering the videos
 
 dataset:
   name: TED-kid

--- a/config/ted-talks.yml
+++ b/config/ted-talks.yml
@@ -1,4 +1,6 @@
-checkpoint_name: None # comment out or set to "None"to run inference from scratch
+inference_checkpoint_name: None # comment out or set to "None" to run inference from scratch
+execute_evaluation: true        # set to false to skip calculating evaluation metrics and plotting
+execute_rendering: true         # set to false to skip rendering the videos
 
 dataset:
   name: TedTalks

--- a/config/tragic-talkers.yml
+++ b/config/tragic-talkers.yml
@@ -93,12 +93,6 @@ metrics:
       normalize_by: bbox
       threshold: 0.2
 
-  - name: Euclidean Distance
-    module: evaluation.metrics.euclidean_distance
-    class: EuclideanDistanceMetric
-    config:
-      normalize_by: bbox
-
   - name: Velocity
     module: evaluation.metrics.velocity
     class: VelocityMetric

--- a/config/tragic-talkers.yml
+++ b/config/tragic-talkers.yml
@@ -1,4 +1,6 @@
-checkpoint_name: None # comment out or set to "None" to run inference from scratch
+inference_checkpoint_name: None # comment out or set to "None" to run inference from scratch
+execute_evaluation: true        # set to false to skip calculating evaluation metrics and plotting
+execute_rendering: true         # set to false to skip rendering the videos
 
 dataset:
   name: TragicTalkers

--- a/src/checkpointer.py
+++ b/src/checkpointer.py
@@ -121,7 +121,7 @@ class Checkpointer:
         config_file_name = os.path.basename(config_file_path)
         shutil.copy(config_file_path, os.path.join(self.checkpoint_dir, config_file_name))
 
-    def load_pose_results(self) -> Dict[str, Dict[str, VideoPoseResult]]:
+    def load_pose_results(self, pose_estimator_names: list[str]) -> Dict[str, Dict[str, VideoPoseResult]]:
         """
         Load all pose results from the checkpoint.
         
@@ -134,7 +134,10 @@ class Checkpointer:
             
         results = {}
         
-        for estimator_name in os.listdir(self.poses_dir):
+        for estimator_name in pose_estimator_names:
+            if estimator_name not in os.listdir(self.poses_dir):
+                raise ValueError(f"No pose results found for estimator {estimator_name}' in checkpoint {self.checkpoint_dir}")
+            
             estimator_dir = os.path.join(self.poses_dir, estimator_name)
             results[estimator_name] = {}
             

--- a/src/evaluation/metrics/metric_result.py
+++ b/src/evaluation/metrics/metric_result.py
@@ -114,12 +114,12 @@ class MetricResult:
             unit=self.unit,
         )
     
-    def aggregate_all(self) -> float:
+    def aggregate_all(self, method: str = 'mean') -> float:
         """
         Get a single scalar value by averaging over all dimensions.
         Useful for getting an overall score for the video.
         """
-        return float(ma.mean(self.values))
+        return self.aggregate(dims=self.axis_names, method=method).values
     
     def get_values_aggregated_to_axis(self, axis_name: str) -> np.ndarray:
         """

--- a/src/evaluation/plots/acceleration_plot.py
+++ b/src/evaluation/plots/acceleration_plot.py
@@ -25,6 +25,7 @@ class AccelerationOverTimePlot(Plot):
     def draw(
         self,
         results: Dict[str, Dict[str, Dict[str, MetricResult]]],
+        add_title: bool = True,
     ) -> List[Tuple[plt.Figure, str]]:
         """
         Draw acceleration over time plot for each model.
@@ -32,6 +33,7 @@ class AccelerationOverTimePlot(Plot):
         Args:
             results: Dictionary mapping:
                     metric_name -> model_name -> video_name -> MetricResult
+            add_title: Whether to add the title to the plot (default: True)
                     
         Returns:
             List[Tuple[plt.Figure, str]]: List of tuples containing the figure and suggested filename
@@ -44,9 +46,10 @@ class AccelerationOverTimePlot(Plot):
         
         figures_and_names = []
         for video_name, model_results in video_groupings.items():
-            fig = self._setup_figure()
+            fig = self._setup_figure(add_title=add_title)
             
-            plt.title(f"{self.config['title']} - {video_name}", pad=20)
+            if add_title:
+                plt.title(f"{self.config['title']} - {video_name}", pad=20)
             
             for model_name, metric_result in model_results.items():
                 frame_accel = metric_result.aggregate([PERSON_AXIS, KEYPOINT_AXIS], method='mean')

--- a/src/evaluation/plots/inference_time_plot.py
+++ b/src/evaluation/plots/inference_time_plot.py
@@ -25,6 +25,7 @@ class InferenceTimePlot(Plot):
     def draw(
         self,
         inference_times: Dict[str, Dict[str, float]],
+        add_title: bool = True,
     ) -> Tuple[plt.Figure, str]:
         """
         Draw inference time plot for each model.
@@ -32,6 +33,7 @@ class InferenceTimePlot(Plot):
         Args:
             inference_times: Dictionary mapping:
                     model_name -> video_name -> inference_time
+            add_title: Whether to add the title to the plot (default: True)
                     
         Returns:
             Tuple[plt.Figure, str]: The figure and suggested filename.
@@ -47,7 +49,7 @@ class InferenceTimePlot(Plot):
         
         df = pd.DataFrame(plot_data)
         
-        fig = self._setup_figure()
+        fig = self._setup_figure(add_title=add_title)
         
         # Create the bar plot
         ax = sns.barplot(

--- a/src/evaluation/plots/keypoint_plot.py
+++ b/src/evaluation/plots/keypoint_plot.py
@@ -32,6 +32,7 @@ class CocoKeypointPlot(Plot):
     def draw(
         self,
         results: Dict[str, Dict[str, Dict[str, MetricResult]]],
+        add_title: bool = True,
     ) -> Tuple[plt.Figure, str]:
         """
         Draw keypoint plot for the given metric. Assumes that all metric results for all pose estimators have the same number of keypoints.
@@ -39,6 +40,7 @@ class CocoKeypointPlot(Plot):
         Args:
             results: Dictionary mapping:
                     metric_name -> model_name -> video_name -> MetricResult
+            add_title: Whether to add the title to the plot (default: True)
                     
         Returns:
             Tuple[plt.Figure, str]: The figure and suggested filename.
@@ -76,7 +78,7 @@ class CocoKeypointPlot(Plot):
         self.config['style'] = 'grid'
         if unit:
             self.config['ylabel'] = f'{self.metric_name} ({unit})'
-        fig = self._setup_figure()
+        fig = self._setup_figure(add_title=add_title)
         
         sns.barplot(
             data=df,

--- a/src/evaluation/plots/keypoint_plot.py
+++ b/src/evaluation/plots/keypoint_plot.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Tuple
 
 import numpy as np
+import numpy.ma as ma
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
@@ -58,9 +59,9 @@ class CocoKeypointPlot(Plot):
             for video_name, metric_result in video_results.items():
                 if self.convert_to_magnitude:
                     metric_result = metric_result.aggregate([COORDINATE_AXIS], method='vector_magnitude')
-                avg_video_keypoint_values = metric_result.aggregate([FRAME_AXIS, PERSON_AXIS], method='mean').values
-                model_values.append(avg_video_keypoint_values)
-            median_model_keypoint_values = np.median(np.stack(model_values, axis=0), axis=0)
+                median_video_keypoint_values = metric_result.aggregate([FRAME_AXIS, PERSON_AXIS], method='median').values
+                model_values.append(median_video_keypoint_values)
+            median_model_keypoint_values = ma.median(np.stack(model_values, axis=0), axis=0)
             
             for keypoint_idx, value in enumerate(median_model_keypoint_values):
                 if keypoint_idx not in COCO_KEYPOINT_NAMES.keys():

--- a/src/evaluation/plots/keypoint_plot.py
+++ b/src/evaluation/plots/keypoint_plot.py
@@ -19,7 +19,7 @@ class CocoKeypointPlot(Plot):
             config={
                 'title': f'Coco Keypoint Plot',
                 'xlabel': 'Keypoint',
-                'ylabel': 'Average Value',
+                'ylabel': 'Median Value',
                 'style': 'white',
                 'figsize': (18, 6),
             }
@@ -60,16 +60,16 @@ class CocoKeypointPlot(Plot):
                     metric_result = metric_result.aggregate([COORDINATE_AXIS], method='vector_magnitude')
                 avg_video_keypoint_values = metric_result.aggregate([FRAME_AXIS, PERSON_AXIS], method='mean').values
                 model_values.append(avg_video_keypoint_values)
-            avg_model_keypoint_values = np.mean(np.stack(model_values, axis=0), axis=0)
+            median_model_keypoint_values = np.median(np.stack(model_values, axis=0), axis=0)
             
-            for keypoint_idx, value in enumerate(avg_model_keypoint_values):
+            for keypoint_idx, value in enumerate(median_model_keypoint_values):
                 if keypoint_idx not in COCO_KEYPOINT_NAMES.keys():
                     continue
 
                 plot_data.append({
                     'Model': model_name,
                     'Keypoint': f"{COCO_KEYPOINT_NAMES[keypoint_idx]} ({keypoint_idx})",
-                    'Average Value': value
+                    'Median Value': value
                 })
         
         df = pd.DataFrame(plot_data)
@@ -77,19 +77,21 @@ class CocoKeypointPlot(Plot):
         self.config['title'] = f'{self.metric_name} by Keypoint and Model'
         self.config['style'] = 'grid'
         if unit:
-            self.config['ylabel'] = f'{self.metric_name} ({unit})'
+            self.config['ylabel'] = f'Median {self.metric_name} ({unit})'
         fig = self._setup_figure(add_title=add_title)
         
         sns.barplot(
             data=df,
             x='Keypoint',
-            y='Average Value',
+            y='Median Value',
             hue='Model',
         )
 
         plt.xticks(rotation=45, ha='right')
+
+        filename = f'keypoint_plot_{self.metric_name.lower().replace(" ", "_")}'
         
-        return (fig, f'keypoint_plot_{self.metric_name}')
+        return (fig, filename)
             
 
 

--- a/src/evaluation/plots/kinematic_distribution_plot.py
+++ b/src/evaluation/plots/kinematic_distribution_plot.py
@@ -81,6 +81,8 @@ class KinematicDistributionPlot(Plot):
                 - List[str]: Human-readable labels for the bins
         """
         diff = self.kinematic_limit / self.n_bins
+        # if n_bins is 10, then we want to have 11 bins, for the last bin which contains all values greater than the kinematic limit
+        # the last value in np.linspace is excluded (that's why we add 2 to n_bins)
         bin_edges = np.linspace(0, self.kinematic_limit + diff, self.n_bins + 2).astype(int)
         
         bin_labels = []
@@ -117,7 +119,7 @@ class KinematicDistributionPlot(Plot):
 
         # First pass: compute the magnitude of the kinematic values and average over videos
         pose_estimator_results = results[self.metric_name]
-        pose_estimator_medians = {} # store the average for each pose estimator over all videos
+        pose_estimator_medians = {} # store the median for each pose estimator over all videos
         pose_estimator_magnitude_results = {} # store the magnitude results for each pose estimator
 
         for pose_estimator_name, video_results in pose_estimator_results.items():

--- a/src/evaluation/plots/kinematic_distribution_plot.py
+++ b/src/evaluation/plots/kinematic_distribution_plot.py
@@ -117,7 +117,7 @@ class KinematicDistributionPlot(Plot):
         add_title: bool = True,
     ) -> Tuple[plt.Figure, str]:
 
-        # First pass: compute the magnitude of the kinematic values and average over videos
+        # First pass: compute the magnitude of the kinematic values and take median over videos
         pose_estimator_results = results[self.metric_name]
         pose_estimator_medians = {} # store the median for each pose estimator over all videos
         pose_estimator_magnitude_results = {} # store the magnitude results for each pose estimator
@@ -130,7 +130,7 @@ class KinematicDistributionPlot(Plot):
             for video_name, metric_result in video_results.items():
                 magnitude_result = metric_result.aggregate([COORDINATE_AXIS], method='vector_magnitude')
 
-                video_magnitudes.append(magnitude_result.aggregate_all())
+                video_magnitudes.append(magnitude_result.aggregate_all(method='median'))
                 pose_estimator_magnitude_results[pose_estimator_name][video_name] = magnitude_result
 
             pose_estimator_medians[pose_estimator_name] = np.median(video_magnitudes)

--- a/src/evaluation/plots/kinematic_distribution_plot.py
+++ b/src/evaluation/plots/kinematic_distribution_plot.py
@@ -80,14 +80,13 @@ class KinematicDistributionPlot(Plot):
                 - np.ndarray: Bin edges for histogram computation
                 - List[str]: Human-readable labels for the bins
         """
-        bin_edges = np.linspace(0, self.kinematic_limit, self.n_bins + 1).astype(int)
+        diff = self.kinematic_limit / self.n_bins
+        bin_edges = np.linspace(0, self.kinematic_limit + diff, self.n_bins + 2).astype(int)
         
         bin_labels = []
         for i in range(len(bin_edges) - 1):
             if i == len(bin_edges) - 2:
                 bin_labels.append(f'> {bin_edges[i]}')
-            elif i == 0:
-                bin_labels.append(f'< {bin_edges[i+1]}')
             else:
                 bin_labels.append(f'[{bin_edges[i]},{bin_edges[i+1]}]')
                 
@@ -117,7 +116,7 @@ class KinematicDistributionPlot(Plot):
 
         # First pass: compute the magnitude of the kinematic values and average over videos
         pose_estimator_results = results[self.metric_name]
-        pose_estimator_averages = {} # store the average for each pose estimator over all videos
+        pose_estimator_medians = {} # store the average for each pose estimator over all videos
         pose_estimator_magnitude_results = {} # store the magnitude results for each pose estimator
 
         for pose_estimator_name, video_results in pose_estimator_results.items():
@@ -131,12 +130,12 @@ class KinematicDistributionPlot(Plot):
                 video_magnitudes.append(magnitude_result.aggregate_all())
                 pose_estimator_magnitude_results[pose_estimator_name][video_name] = magnitude_result
 
-            pose_estimator_averages[pose_estimator_name] = np.mean(video_magnitudes)
+            pose_estimator_medians[pose_estimator_name] = np.median(video_magnitudes)
 
         if self.kinematic_limit is None:
             # Calculate the maximum average magnitude of all pose estimators to set the bounds of the plot
             # This maximum value is increased by 20%
-            raw_limit = max(pose_estimator_averages.values()) * 1.20
+            raw_limit = max(pose_estimator_medians.values()) * 1.20
             self.kinematic_limit = self._round_to_nearest_magnitude(raw_limit)
         
         if self.unit:

--- a/src/evaluation/plots/kinematic_distribution_plot.py
+++ b/src/evaluation/plots/kinematic_distribution_plot.py
@@ -112,6 +112,7 @@ class KinematicDistributionPlot(Plot):
     def draw(
         self,
         results: Dict[str, Dict[str, Dict[str, MetricResult]]],
+        add_title: bool = True,
     ) -> Tuple[plt.Figure, str]:
 
         # First pass: compute the magnitude of the kinematic values and average over videos
@@ -140,7 +141,7 @@ class KinematicDistributionPlot(Plot):
         
         if self.unit:
             self.config['xlabel'] = f'{self.metric_name} ({self.unit})'
-        fig = self._setup_figure()
+        fig = self._setup_figure(add_title=add_title)
 
         # Store lines for updating legend later
         lines = []

--- a/src/evaluation/plots/plot.py
+++ b/src/evaluation/plots/plot.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Tuple
 import matplotlib.pyplot as plt
 import seaborn as sns
 from evaluation.metrics.metric_result import MetricResult
+from utils import get_color_palette
 
 
 class Plot(ABC):
@@ -34,10 +35,10 @@ class Plot(ABC):
             self.config['dpi'] = 300
         if 'style' not in self.config:
             self.config['style'] = 'white'
-        self.config['palette'] = "tab10"
+        self.config['palette'] = get_color_palette()
         
         sns.set_style(self.config['style'])
-        sns.color_palette(self.config['palette'])
+        sns.set_palette(self.config['palette'])
         sns.set_context("paper")
         
     @abstractmethod

--- a/src/evaluation/plots/plot.py
+++ b/src/evaluation/plots/plot.py
@@ -44,6 +44,7 @@ class Plot(ABC):
     def draw(
         self,
         results: Dict[str, Dict[str, Dict[str, MetricResult]]],
+        add_title: bool = True,
     ) -> Tuple[plt.Figure, str]:
         """
         Draw the plot using the provided results.
@@ -51,6 +52,7 @@ class Plot(ABC):
         Args:
             results: Dictionary mapping:
                     metric_name -> model_name -> video_name -> MetricResult
+            add_title: Whether to add the title to the plot (default: True)
             
         Returns:
             Tuple containing:
@@ -59,8 +61,13 @@ class Plot(ABC):
         """
         pass
     
-    def _setup_figure(self) -> plt.Figure:
-        """Set up the figure with standard configuration."""
+    def _setup_figure(self, add_title: bool = True) -> plt.Figure:
+        """
+        Set up the figure with standard configuration.
+        
+        Args:
+            add_title: Whether to add the title to the plot (default: True)
+        """
         fig = plt.figure(figsize=self.config['figsize'], dpi=self.config['dpi'])
         plt.tight_layout()
 
@@ -71,7 +78,7 @@ class Plot(ABC):
         plt.gca().spines['bottom'].set_visible(False)
 
         
-        if 'title' in self.config:
+        if add_title and 'title' in self.config:
             plt.title(self.config['title'])
         if 'xlabel' in self.config:
             plt.xlabel(self.config['xlabel'], labelpad=10)

--- a/src/evaluation/plots/result_table.py
+++ b/src/evaluation/plots/result_table.py
@@ -7,7 +7,7 @@ from evaluation.metrics.metric_result import MetricResult
 from evaluation.utils import aggregate_results_over_all_videos
 
 
-def generate_result_table(metric_results: Dict[str, Dict[str, Dict[str, MetricResult]]]) -> None:
+def generate_result_table(metric_results: Dict[str, Dict[str, Dict[str, MetricResult]]]) -> pd.DataFrame:
     aggregated_results = aggregate_results_over_all_videos(metric_results)
 
     first_metric = list(metric_results.keys())[0]
@@ -40,7 +40,7 @@ def generate_result_table(metric_results: Dict[str, Dict[str, Dict[str, MetricRe
         intfmt=","
     )
     print(table)
-    return table
+    return df
     
 
 

--- a/src/evaluation/utils.py
+++ b/src/evaluation/utils.py
@@ -43,12 +43,21 @@ def aggregate_results_over_all_videos(metric_results: Dict[str, Dict[str, Dict[s
     aggregated_results = {}
     for metric_name, pose_estimator_results in metric_results.items():
         aggregated_results[metric_name] = {}
+
+        use_mean = any(substr in metric_name.lower() for substr in ['pck'])
         
         for pose_estimator_name, video_results in pose_estimator_results.items():
             aggregated_video_results = []
             for video_name, result in video_results.items():
-                aggregated_video_results.append(result.aggregate_all())
-            aggregated_results[metric_name][pose_estimator_name] = np.round(np.mean(aggregated_video_results), decimals=2)
+                if use_mean:
+                    aggregated_video_results.append(result.aggregate_all(method='mean'))
+                else:
+                    aggregated_video_results.append(result.aggregate_all(method='median'))
+
+            if use_mean:
+                aggregated_results[metric_name][pose_estimator_name] = np.round(np.mean(aggregated_video_results), decimals=2)
+            else:
+                aggregated_results[metric_name][pose_estimator_name] = np.round(np.median(aggregated_video_results), decimals=2)
 
     return aggregated_results
 

--- a/src/evaluation/visualizer/base_visualizer.py
+++ b/src/evaluation/visualizer/base_visualizer.py
@@ -3,6 +3,7 @@ import os
 from typing import Dict
 
 from matplotlib import pyplot as plt
+import pandas as pd
 
 from evaluation.metrics import MetricResult
 from checkpointer import Checkpointer
@@ -24,11 +25,11 @@ class Visualizer:
         output_path = os.path.join(self.plots_dir, filename)
         fig.savefig(output_path, bbox_inches='tight', dpi=300)
 
-    def _save_table(self, table: str, filename: str) -> None:
+    def _save_table(self, df: pd.DataFrame, filename: str) -> None:
         """Save a table to the plots directory."""
         output_path = os.path.join(self.plots_dir, filename)
-        with open(output_path, "w") as f:
-            f.write(table)
+        df.to_csv(output_path, index=False)
+
 
     @abstractmethod
     def generate_all_plots(self, pose_results: Dict[str, Dict[str, Dict[str, MetricResult]]]):

--- a/src/evaluation/visualizer/maskbench_visualizer.py
+++ b/src/evaluation/visualizer/maskbench_visualizer.py
@@ -50,8 +50,8 @@ class MaskBenchVisualizer(Visualizer):
             self._save_plot(fig, filename)
 
         pose_results = self.calculate_kinematic_magnitudes(pose_results)
-        table = generate_result_table(pose_results)
-        self._save_table(table, "result_table.txt")
+        table_df = generate_result_table(pose_results)
+        self._save_table(table_df, "result_table.csv")
 
         
     def set_maskanyone_ui_inference_times(self, inference_times: Dict[str, Dict[str, float]]) -> Dict[str, Dict[str, float]]:

--- a/src/evaluation/visualizer/maskbench_visualizer.py
+++ b/src/evaluation/visualizer/maskbench_visualizer.py
@@ -4,7 +4,7 @@ from typing import Dict
 from matplotlib import pyplot as plt
 
 from evaluation.metrics import MetricResult
-from evaluation.plots import KinematicDistributionPlot, CocoKeypointPlot, generate_result_table, InferenceTimePlot
+from evaluation.plots import KinematicDistributionPlot, CocoKeypointPlot, generate_result_table, InferenceTimePlot, AccelerationOverTimePlot
 from checkpointer import Checkpointer
 from evaluation.metrics.metric_result import COORDINATE_AXIS
 from .base_visualizer import Visualizer
@@ -20,26 +20,26 @@ class MaskBenchVisualizer(Visualizer):
 
         if "Velocity" in pose_results.keys():
             velocity_distribution_plot = KinematicDistributionPlot(metric_name="Velocity")
-            fig, filename = velocity_distribution_plot.draw(pose_results)
+            fig, filename = velocity_distribution_plot.draw(pose_results, add_title=False)
             self._save_plot(fig, filename)
 
         if "Acceleration" in pose_results.keys():
             acceleration_distribution_plot = KinematicDistributionPlot(metric_name="Acceleration")
-            fig, filename = acceleration_distribution_plot.draw(pose_results)
+            fig, filename = acceleration_distribution_plot.draw(pose_results, add_title=False)
             self._save_plot(fig, filename)
 
             coco_keypoint_plot = CocoKeypointPlot(metric_name="Acceleration")
-            fig, filename = coco_keypoint_plot.draw(pose_results)
+            fig, filename = coco_keypoint_plot.draw(pose_results, add_title=False)
             self._save_plot(fig, filename)
 
         if "Jerk" in pose_results.keys():
             jerk_distribution_plot = KinematicDistributionPlot(metric_name="Jerk")
-            fig, filename = jerk_distribution_plot.draw(pose_results)
+            fig, filename = jerk_distribution_plot.draw(pose_results, add_title=False)
             self._save_plot(fig, filename)
 
         if "Euclidean Distance" in pose_results.keys():
             coco_keypoint_plot = CocoKeypointPlot(metric_name="Euclidean Distance")
-            fig, filename = coco_keypoint_plot.draw(pose_results)
+            fig, filename = coco_keypoint_plot.draw(pose_results, add_title=False)
             self._save_plot(fig, filename)
 
         inference_times = self.checkpointer.load_inference_times()

--- a/src/evaluation/visualizer/maskbench_visualizer.py
+++ b/src/evaluation/visualizer/maskbench_visualizer.py
@@ -45,6 +45,7 @@ class MaskBenchVisualizer(Visualizer):
         inference_times = self.checkpointer.load_inference_times()
         if inference_times:
             inference_times = self.set_maskanyone_ui_inference_times(inference_times)
+            inference_times = self.sort_inference_times_pose_estimator_order(inference_times, pose_results)
             inference_time_plot = InferenceTimePlot()
             fig, filename = inference_time_plot.draw(inference_times)
             self._save_plot(fig, filename)
@@ -85,4 +86,26 @@ class MaskBenchVisualizer(Visualizer):
                         magnitude_values = metric_result.aggregate([COORDINATE_AXIS], method='vector_magnitude')
                         pose_results[metric_name][model_name][video_name] = magnitude_values
         return pose_results
+
+    def sort_inference_times_pose_estimator_order(self, inference_times: Dict[str, Dict[str, float]], pose_results: Dict[str, Dict[str, Dict[str, MetricResult]]]) -> Dict[str, Dict[str, float]]:
+        """
+        Sort the inference times according to the order in pose_results.
+        
+        Args:
+            inference_times: Dictionary containing inference times for each pose estimator
+            pose_results: Dictionary containing pose estimation results, used to determine the order
+            
+        Returns:
+            Dictionary containing sorted inference times
+        """
+        # Get the list of pose estimators from any metric in pose_results
+        first_metric = next(iter(pose_results))
+        pose_estimator_order = list(pose_results[first_metric].keys())
+        
+        sorted_inference_times = {}
+        for pose_estimator in pose_estimator_order:
+            if pose_estimator in inference_times:
+                sorted_inference_times[pose_estimator] = inference_times[pose_estimator]
+        return sorted_inference_times
+
         

--- a/src/evaluation/visualizer/maskbench_visualizer.py
+++ b/src/evaluation/visualizer/maskbench_visualizer.py
@@ -37,11 +37,6 @@ class MaskBenchVisualizer(Visualizer):
             fig, filename = jerk_distribution_plot.draw(pose_results, add_title=False)
             self._save_plot(fig, filename)
 
-        if "Euclidean Distance" in pose_results.keys():
-            coco_keypoint_plot = CocoKeypointPlot(metric_name="Euclidean Distance")
-            fig, filename = coco_keypoint_plot.draw(pose_results, add_title=False)
-            self._save_plot(fig, filename)
-
         inference_times = self.checkpointer.load_inference_times()
         if inference_times:
             inference_times = self.set_maskanyone_ui_inference_times(inference_times)

--- a/src/evaluation/visualizer/maskbench_visualizer.py
+++ b/src/evaluation/visualizer/maskbench_visualizer.py
@@ -4,7 +4,7 @@ from typing import Dict
 from matplotlib import pyplot as plt
 
 from evaluation.metrics import MetricResult
-from evaluation.plots import KinematicDistributionPlot, CocoKeypointPlot, generate_result_table, InferenceTimePlot, AccelerationOverTimePlot
+from evaluation.plots import KinematicDistributionPlot, CocoKeypointPlot, generate_result_table, InferenceTimePlot
 from checkpointer import Checkpointer
 from evaluation.metrics.metric_result import COORDINATE_AXIS
 from .base_visualizer import Visualizer

--- a/src/inference/inference_engine.py
+++ b/src/inference/inference_engine.py
@@ -14,7 +14,7 @@ class InferenceEngine:
         results = {}
         if self.checkpointer.load_checkpoint:
             print(f"Loading results from checkpoint {self.checkpointer.checkpoint_dir}")
-            results = self.checkpointer.load_pose_results()
+            results = self.checkpointer.load_pose_results(pose_estimator_names=list(map(lambda x: x.name, self.pose_estimators)))
             
         for estimator in self.pose_estimators:
             if estimator.name not in results:

--- a/src/main.py
+++ b/src/main.py
@@ -35,7 +35,7 @@ def main():
     execute_evaluation = config.get("execute_evaluation", True)
     execute_rendering = config.get("execute_rendering", True)
     
-    run(dataset, pose_estimators, metrics, checkpointer, execute_evaluation=execute_evaluation, execute_rendering=execute_rendering)
+    run(dataset, pose_estimators, metrics, checkpointer, execute_evaluation, execute_rendering)
     print("Done")
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -27,33 +27,40 @@ def main():
     metrics = load_metrics(metric_specifications)
     print("Available metrics:", [metric.name for metric in metrics])
 
-    checkpoint_name = config.get("checkpoint_name", None)
+    checkpoint_name = config.get("inference_checkpoint_name", None)
     checkpoint_name = checkpoint_name if checkpoint_name != "None" else None
     checkpointer = Checkpointer(dataset.name, checkpoint_name)
     checkpointer.save_config(config_file_path)
+
+    execute_evaluation = config.get("execute_evaluation", True)
+    execute_rendering = config.get("execute_rendering", True)
     
-    run(dataset, pose_estimators, metrics, checkpointer)
+    run(dataset, pose_estimators, metrics, checkpointer, execute_evaluation=execute_evaluation, execute_rendering=execute_rendering)
     print("Done")
 
 
-def run(dataset: Dataset, pose_estimators: List[PoseEstimator], metrics: List[Metric], checkpointer: Checkpointer):
+def run(dataset: Dataset, pose_estimators: List[PoseEstimator], metrics: List[Metric], checkpointer: Checkpointer, execute_evaluation: bool, execute_rendering: bool):
     inference_engine = InferenceEngine(dataset, pose_estimators, checkpointer)
     gt_pose_results = dataset.get_gt_pose_results()
     pose_results = inference_engine.estimate_pose_keypoints()
     
-    evaluator = Evaluator(metrics=metrics)
-    metric_results = evaluator.evaluate(pose_results, gt_pose_results)
+    if execute_evaluation:
+        print("Executing evaluation.")
+        evaluator = Evaluator(metrics=metrics)
+        metric_results = evaluator.evaluate(pose_results, gt_pose_results)
 
-    visualizer = MaskBenchVisualizer(checkpointer)
-    visualizer.generate_all_plots(metric_results)
+        visualizer = MaskBenchVisualizer(checkpointer)
+        visualizer.generate_all_plots(metric_results)
 
-    estimators_point_pairs = {est.name: est.get_keypoint_pairs() for est in pose_estimators}
-    if gt_pose_results and dataset.get_gt_keypoint_pairs() is not None:
-        pose_results["GroundTruth"] = gt_pose_results
-        estimators_point_pairs["GroundTruth"] = dataset.get_gt_keypoint_pairs()
+    if execute_rendering:
+        print("Executing rendering.")
+        estimators_point_pairs = {est.name: est.get_keypoint_pairs() for est in pose_estimators}
+        if gt_pose_results and dataset.get_gt_keypoint_pairs() is not None:
+            pose_results["GroundTruth"] = gt_pose_results
+            estimators_point_pairs["GroundTruth"] = dataset.get_gt_keypoint_pairs()
 
-    pose_renderer = PoseRenderer(dataset, estimators_point_pairs, checkpointer)
-    pose_renderer.render_all_videos(pose_results)
+        pose_renderer = PoseRenderer(dataset, estimators_point_pairs, checkpointer)
+        pose_renderer.render_all_videos(pose_results)
 
 
 def load_config() -> dict:

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,18 @@ import json
 from typing import List
 from inference import FramePoseResult, PersonPoseResult, PoseKeypoint
 
+def get_color_palette() -> list:
+    return [
+        '#4477AA', # blue
+        '#66CCEE', # cyan
+        '#8a8a8a', # grey
+        '#228833', # green
+        '#CCBB44', # yellow
+        '#EE6677', # red
+        '#AA4499', # purple
+        '#DDAA33', # yellow
+    ]
+
 def convert_keypoints_to_coco_format(frame_results: List[FramePoseResult], model_to_coco_mapping: list) -> List[FramePoseResult]:
     for frame in frame_results: 
         if frame and frame.persons: # ensuring they are not None


### PR DESCRIPTION
- [x] Added config option to enable/disable evaluation and rendering (! update your config.yml)
- [x] Set correct scale of distribution charts (using median instead of mean)
- [x] Add option to add or remove the title of a plot
- [x] Save output tables as CSV
- [x] Ensure consistent order and color of pose estimators in plots and rendered videos. We now make sure, that the pose estimators are always in the same order (especially when loading from a checkpoint). This allows us to have the same color for each pose estimator across all plots and also rendering files). We use a color palette, which is friendly for colorblind people. closes #129 