### PR TITLE
fix: inference_times.json schema (3-shape migration) + throttled progress logging

### DIFF
--- a/docs/inference-times-logging-fix-plan.md
+++ b/docs/inference-times-logging-fix-plan.md
@@ -1,0 +1,241 @@
+# Fix plan — `inference_times.json` schema + progress logging
+
+Status: **plan for review (rev. 2 — adversarial audit folded in).** Implements fixes on a branch as a
+reviewable PR; Sharjeel reviews the diff against this doc. Scope = the two commits on
+`origin/envision_gesture_challenge` (`6f14949` hide ffmpeg output, `06b8381` better progress logging).
+
+First concrete instance of the versioned-schema work — see issues **#153** (versioned schemas) and **#154**
+(run manifest).
+
+> **Rev. 2 changelog (what the audit changed):** the earlier plan assumed only two on-disk shapes
+> (legacy-flat, new-nested). There is a **third, already-real shape** — Sharjeel's *mixed* file
+> (bookkeeping keys **and** estimator keys at top level, **no** `"estimators"` key). The old
+> `load = data.get("estimators", data)` one-liner **silently corrupts** that shape. F1 below now normalises
+> all three shapes on read **and** in migration. Also fixed: line anchors point at Sharjeel's file; `main.py`
+> is explicitly reconciled (it is 2-arg on this branch); backend instructions de-contradicted; eval-plot
+> severity re-scoped; secondary bugs flagged.
+
+---
+
+## 0. Pre-flight / merge gate (do before any F-fix)
+
+These fixes target **Sharjeel's code**, which is **not yet on this branch**. Order matters:
+
+1. **Branch** `fix/inference-times-schema-and-logging` off an integration point that contains both
+   `6f14949` + `06b8381`, so the PR diff is *only* these fixes.
+2. **Resolve the `main.py` conflict deliberately.** This branch's `main.py` has the `run_plan` guard **and**
+   is still **2-arg**: `Checkpointer(dataset.name, checkpoint_name)` ([src/main.py:30](../src/main.py#L30)).
+   Sharjeel's is **3-arg**: `Checkpointer(dataset.name, len(dataset), checkpoint_name)`
+   (`origin/envision_gesture_challenge:src/main.py:28`). **Post-merge `main.py` must keep BOTH** the
+   `run_plan` block and the 3-arg call. Verify by grep before continuing — do not assume the merge got it
+   right. A 2-arg survivor puts `checkpoint_name` into `total_videos` → `self.total_videos` becomes a string.
+3. **Confirm `total_videos` flows in** wherever `Checkpointer` is constructed (see F2).
+
+---
+
+## The contract at the centre of this
+
+`06b8381` changed `inference_times.json` from flat `estimator → {video → seconds}` to a mix of bookkeeping
+keys **and** estimator keys at the same top level. That top level is iterated as "estimators" by 4 consumers.
+
+### Three on-disk shapes exist (this is the crux the first plan missed)
+
+| Shape | Looks like | Where it comes from |
+|---|---|---|
+| **legacy-flat** | `{ "Est": { "v": 1.2 } }` | every real file on disk today (incl. the 0608 corpus) |
+| **mixed** | `{ "metadata": {…}, "Est": {…}, "videos_processed_per_estimator": {…}, … }` | Sharjeel's **unfixed** `save_inference_time` (no `"estimators"` key) |
+| **nested (target)** | `{ "metadata": {…}, "estimators": { "Est": {…} }, … }` | what this plan writes |
+
+A single discriminator of `"estimators" in data` is **not** enough — it misclassifies *mixed* as *legacy* and
+folds the bookkeeping keys into the estimator map. The fix keys off a **RESERVED** set instead.
+
+### Target schema (decided: nest under `estimators`, add `schema_version`)
+
+```jsonc
+{
+  "schema_version": 1,
+  "metadata": { "total_videos": 29098, "total_time_taken": 1234.5 },
+  "estimators": { "MediaPipePoseWorldLandmarker": { "<clip>": 1.23 } },
+  "videos_processed_per_estimator": { "MediaPipePoseWorldLandmarker": 1023 },
+  "total_time_per_estimator":       { "MediaPipePoseWorldLandmarker": 1234.5 }
+}
+```
+
+```python
+RESERVED = {"schema_version", "metadata", "estimators",
+            "videos_processed_per_estimator", "total_time_per_estimator"}
+```
+
+---
+
+## F1 — Normalise all three shapes on read + migrate on write  ★ root cause
+
+**Problem.** (a) Bookkeeping keys leak into estimator iteration. (b) `save_inference_time`
+([checkpointer.py:118](../src/checkpointer.py#L118), Sharjeel's version) only creates the bookkeeping keys in
+the *new-file* branch, so loading any pre-existing file then doing
+`inference_times["videos_processed_per_estimator"]` raises `KeyError`. Verified: the 0608 corpus file is
+legacy-flat (top-level keys = `["MediaPipePoseWorldLandmarker"]`).
+
+**Fix — one shared normaliser** (new helper, used by both read and migrate):
+
+```python
+def _estimator_timings(data: dict) -> dict:
+    """estimator -> {video: seconds}, from any of the 3 on-disk shapes."""
+    if "estimators" in data:                              # nested (target)
+        return data["estimators"]
+    if any(k in data for k in RESERVED):                  # mixed (Sharjeel unfixed)
+        return {k: v for k, v in data.items() if k not in RESERVED}
+    return data                                           # legacy-flat
+```
+
+**Fix — `load_inference_times`** ([checkpointer.py:210](../src/checkpointer.py#L210), Sharjeel's version):
+wrap `json.load` in `try/except json.JSONDecodeError` (the read path holds no lock; a mid-write file must not
+crash the loader — `build_run_report.ps1:60` already guards this, the Python side does not) and
+`return _estimator_timings(data)`. The visualizer/`inference_time_plot` then receive a clean estimator map for
+**all three** shapes — **no changes needed in the evaluation code**.
+
+**Fix — `save_inference_time` migration** (write path):
+
+```python
+def _migrate(self, data: dict) -> dict:
+    if "estimators" in data and "metadata" in data:      # already current
+        data.setdefault("videos_processed_per_estimator", {})
+        data.setdefault("total_time_per_estimator", {})
+        data.setdefault("schema_version", 1)
+        return data
+    est = _estimator_timings(data)                        # excludes RESERVED → no fold-in
+    return {
+        "schema_version": 1,
+        "metadata": {"total_videos": self.total_videos,
+                     "total_time_taken": sum(sum(v.values()) for v in est.values())},
+        "estimators": est,
+        "videos_processed_per_estimator": {e: len(v) for e, v in est.items()},
+        "total_time_per_estimator": {e: sum(v.values()) for e, v in est.items()},
+    }
+```
+
+Because migration goes through `_estimator_timings`, a **mixed** file does **not** fold `metadata` /
+roll-up dicts into `estimators` (the bug the audit caught). Migration is idempotent and recomputes totals
+from data (self-healing).
+
+**Consumers updated by F1:**
+- `checkpointer.py` — `_estimator_timings`, `load_inference_times`, `save_inference_time` (+ `_migrate`).
+- `web/build_run_report.ps1` — read `$it.estimators` if present, else mixed/legacy fallback (mirror the 3-shape
+  logic; ~5 lines). Keep the existing mid-write `try/catch`.
+- `backend/main.py` — `_inference_times()` returns `_estimator_timings(data)` (the normalised map).
+  `dashboard_stats` **keeps its current robust loop** (`for est, vids in _inference_times(r).items(): if
+  isinstance(vids, dict): …`) which already works across all runs on disk (all legacy today). **Do not** switch
+  it to read `metadata.total_time_taken` directly — that KeyErrors on every existing legacy run. *Optional:* use
+  `metadata.total_time_taken` **only when present**, else fall back to the loop. (This removes the rev-1
+  contradiction.)
+
+**Eval-plot severity — re-scoped (audit finding).** In the *full* eval pipeline the bogus keys are actually
+filtered out before plotting: `sort_inference_times_pose_estimator_order`
+([maskbench_visualizer.py:101-103](../src/evaluation/visualizer/maskbench_visualizer.py#L101)) keeps only
+estimators present in `metric_results`, so the "3 bogus bars" may **not** reproduce via the visualizer. The
+**definite** corruption is in consumers that average the raw dict with **no** sort filter — `build_run_report.ps1`
+and `backend/main.py` — plus the **definite** `KeyError` crash-on-resume. F1 still fixes all of these at the
+root; we just don't oversell the plot symptom.
+
+**Test.** `tests/inference/test_inference_times.py`:
+- Fresh dir → schema has `schema_version/metadata/estimators/…`; `load_inference_times()` returns
+  `{est: {video: sec}}`; roll-ups correct.
+- **Legacy** file `{"Est": {"v1": 1.0}}` → `save_inference_time("Est","v2",2.0)`: no KeyError; migrated;
+  `total_time_per_estimator["Est"] == 3.0`; `videos_processed == 2`.
+- **Mixed** file (`metadata` + `Est` + roll-ups, no `"estimators"`) → `load_inference_times()` returns **only**
+  `{"Est": …}` (RESERVED stripped); a subsequent save migrates without folding bookkeeping keys into estimators.
+- Overwrite same `(est, video)` → counts/totals unchanged.
+- Corrupt/truncated JSON → `load_inference_times()` returns `{}` (no exception).
+
+**Risk.** Low–medium. Localised to read/write helpers; reader contracts preserved; migration idempotent.
+
+---
+
+## F2 — `Checkpointer(total_videos)` callers
+
+**Problem.** `06b8381` inserted required positional `total_videos` mid-signature. It updated `main.py` (on its
+branch) but not [src/scripts/raw_masked_experiment.py:69](../src/scripts/raw_masked_experiment.py#L69):
+`Checkpointer(dataset_name, f"{dataset_name}-{strategy}")` → strategy string lands in `total_videos`,
+`checkpoint_name` → `None` → a *new* empty checkpoint instead of loading.
+
+**Fix (primary, keeps Sharjeel's signature).** `Checkpointer(dataset_name, len(dataset), f"{dataset_name}-{strategy}")`.
+
+**Fix (alternative for review).** `def __init__(self, dataset_name, checkpoint_name=None, *, total_videos=None)`
+— append as keyword-with-default so no positional caller can silently break; `total_videos` degrades to
+`metadata.total_videos: null` when unset. *Recommend primary; flag this for Sharjeel.*
+
+**Heads-up (separate pre-existing bug, not ours to fix here but note it):**
+[raw_masked_experiment.py:70](../src/scripts/raw_masked_experiment.py#L70) calls `load_pose_results()` with **no
+arg**, but the signature requires `pose_estimator_names`
+([checkpointer.py:146](../src/checkpointer.py#L146)). So this script is **already broken** independent of the
+signature change — don't let a green F2 unit test imply the script runs end-to-end. Flag it; fix out of scope.
+
+**Test.** Construct `Checkpointer` both in-repo ways; assert `total_videos` is the int and `checkpoint_name` is
+the intended value (not swapped).
+
+**Risk.** Low. One-line caller change.
+
+---
+
+## F3 — Progress logging volume
+
+**Problem.** `logging.info(progress.__str__())` runs **every** video
+([inference_engine.py](../src/inference/inference_engine.py)) and **every** npz
+([npz_format.py](../src/save_formats/npz_format.py)) → ~29k near-duplicate bar-strings to `*_maskbench.log` +
+per-iteration I/O. tqdm already renders the live bar on stderr.
+
+**Fix.** Throttle the **file** log to milestones via a `_log_progress(done, total)` helper:
+`step = max(1, total // 20)` (≈ every 5%) + a final `Done: N processed, M skipped`. Keep the live tqdm bar.
+
+**Note (audit).** For small runs (`total < 20`), `total // 20 == 0 → step = 1`, i.e. logs every item — a no-op
+throttle, which is fine. The real check is the **100-item unit test** (assert ≤ ~21 progress records), not the
+≤20-clip verify run.
+
+**Risk.** Low. Logging-only.
+
+---
+
+## F4 — tqdm thread-safety (latent; decision needed)
+
+**Problem.** Per-estimator bars + bare `print()` inside the `ThreadPoolExecutor` (workers = #estimators), no
+`position=`. Garbles with >1 estimator. Not hit today (single estimator).
+
+**Fix / caveat (audit).** A real `position=` fix needs an **estimator index threaded through**
+`executor.submit` ([inference_engine.py:46-50](../src/inference/inference_engine.py#L46)) — the estimator
+object only has `.name`, not an index. `npz_format.create` is sequential, so it needs no `position=`.
+**Decision for Sharjeel:** thread the index through and set `position=`/`leave=True`, **or** defer with
+`# TODO(threadsafe)` since it's latent. Plan defers unless he wants it now.
+
+**Risk.** Low. Console-only.
+
+---
+
+## F5 — `6f14949` ffmpeg quieting — adopt as-is ✅
+
+`-hide_banner -loglevel error` is correct and self-contained. Merged unmodified.
+
+---
+
+## Sequencing, verification, PR
+
+1. **Merge gate (§0)** — branch with both commits; reconcile `main.py` to keep `run_plan` **and** 3-arg.
+2. **Order.** F1 (normaliser + migration + reader updates + tests) → F2 (caller) → F3 → F4 (or defer). F5 via merge.
+3. **Verify** on a tiny re-run (≤20 clips) that **resumes a legacy-schema checkpoint** (the KeyError case today):
+   confirm no crash, migrated `inference_times.json` (has `schema_version`/`estimators`), eval inference-time
+   plot shows one real estimator, and `build_run_report.ps1` + `/api/dashboard/stats` show a sane avg. Also feed
+   a hand-written **mixed** file through `load_inference_times` and assert RESERVED keys are stripped. Do **not**
+   re-run the full 29k.
+4. **Tests green** (`pytest`); the legacy + mixed migration tests (F1) and the caller test (F2) are the bar.
+5. **One PR**, this doc linked; commits map 1:1 to F1–F4 so Sharjeel reviews each fix against its section.
+6. **Rollback.** Each fix self-contained. Migration is forward-only but non-destructive (recomputes from data);
+   keep a copy of one real `inference_times.json` until the eval plot + report are confirmed correct.
+
+---
+
+## Open decisions for Sharjeel
+
+- **F2 signature:** fix the caller (keep his positional `total_videos`) vs. keyword-with-default (defensive,
+  changes signature). Plan recommends the former.
+- **F4 tqdm:** thread the index through for `position=` now, vs. defer (latent until multi-estimator configs).
+- **`schema_version`:** introduce it now on `inference_times.json` (seeds #153) — confirm the value/semantics.
+- **Naming:** `estimators` as the nesting key alongside `total_time_per_estimator` / `videos_processed_per_estimator`.

--- a/src/checkpointer.py
+++ b/src/checkpointer.py
@@ -12,6 +12,63 @@ from tqdm import tqdm
 
 from pose_result_class import VideoPoseResult
 
+
+# ── inference_times.json schema ───────────────────────────────────────────────
+# Current on-disk schema (version 1):
+#   {
+#     "schema_version": 1,
+#     "metadata": {"total_videos": int, "total_time_taken": float},
+#     "estimators": {<estimator>: {<video>: seconds}},
+#     "videos_processed_per_estimator": {<estimator>: int},
+#     "total_time_per_estimator": {<estimator>: float},
+#   }
+# Two earlier shapes exist on disk and must be read without crashing or corrupting:
+#   legacy-flat: {<estimator>: {<video>: seconds}}            (no bookkeeping keys)
+#   mixed:       bookkeeping keys + <estimator> keys at the top level, no "estimators"
+INFERENCE_TIMES_SCHEMA_VERSION = 1
+_RESERVED_INFERENCE_KEYS = {
+    "schema_version", "metadata", "estimators",
+    "videos_processed_per_estimator", "total_time_per_estimator",
+}
+
+
+def estimator_timings(data: dict) -> dict:
+    """Return ``{estimator: {video: seconds}}`` from any inference_times shape.
+
+    Normalises the three on-disk shapes (nested / mixed / legacy-flat) so callers
+    that iterate estimators never see the reserved bookkeeping keys.
+    """
+    if "estimators" in data:                                  # nested (current)
+        return data["estimators"]
+    if any(k in data for k in _RESERVED_INFERENCE_KEYS):      # mixed (strip reserved)
+        return {k: v for k, v in data.items() if k not in _RESERVED_INFERENCE_KEYS}
+    return data                                               # legacy-flat
+
+
+def migrate_inference_times(data: dict, total_videos: int) -> dict:
+    """Normalise any inference_times shape (incl. ``{}``) to the current schema.
+
+    Idempotent and non-destructive: roll-ups are recomputed from the estimator
+    timings, never assumed, so re-migrating a current file is a no-op.
+    """
+    if "estimators" in data and "metadata" in data:           # already current
+        data.setdefault("schema_version", INFERENCE_TIMES_SCHEMA_VERSION)
+        data.setdefault("videos_processed_per_estimator", {})
+        data.setdefault("total_time_per_estimator", {})
+        return data
+    est = estimator_timings(data)                             # excludes reserved keys
+    return {
+        "schema_version": INFERENCE_TIMES_SCHEMA_VERSION,
+        "metadata": {
+            "total_videos": total_videos,
+            "total_time_taken": sum(sum(v.values()) for v in est.values()),
+        },
+        "estimators": est,
+        "videos_processed_per_estimator": {e: len(v) for e, v in est.items()},
+        "total_time_per_estimator": {e: sum(v.values()) for e, v in est.items()},
+    }
+
+
 class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.floating):
@@ -122,41 +179,38 @@ class Checkpointer:
         inference_file_path = os.path.join(self.checkpoint_dir, "inference_times.json")
         lock = FileLock(inference_file_path + ".lock")  # to prevent concurrent access
         
-        # Load existing inference times or create new dict if file doesn't exist
+        # Load existing inference times (any on-disk shape) or start fresh, then
+        # normalise to the current schema before updating. migrate_* handles the
+        # legacy-flat / mixed / empty cases so this never KeyErrors on resume.
         with lock:
+            data = {}
             if os.path.exists(inference_file_path):
                 with open(inference_file_path, 'r') as f:
-                    inference_times = json.load(f)
-            else:
-                inference_times = {
-                    "metadata": {
-                        "total_videos": self.total_videos, # total videos in the dataset
-                        "total_time_taken": 0.0
-                    },
-                    "videos_processed_per_estimator": {},
-                    "total_time_per_estimator": {}
-                }
+                    try:
+                        data = json.load(f)
+                    except json.JSONDecodeError:
+                        logging.warning(f"Could not parse {inference_file_path}; rebuilding it.")
+                        data = {}
+            inference_times = migrate_inference_times(data, self.total_videos)
 
-            if estimator_name not in inference_times:
-                inference_times[estimator_name] = {}
-            if estimator_name not in inference_times["videos_processed_per_estimator"]:
-                inference_times["videos_processed_per_estimator"][estimator_name] = 0
-            if estimator_name not in inference_times["total_time_per_estimator"]:
-                inference_times["total_time_per_estimator"][estimator_name] = 0.0
+            estimators = inference_times["estimators"]
+            estimators.setdefault(estimator_name, {})
+            inference_times["videos_processed_per_estimator"].setdefault(estimator_name, 0)
+            inference_times["total_time_per_estimator"].setdefault(estimator_name, 0.0)
 
-            if video_name in inference_times[estimator_name]:
+            if video_name in estimators[estimator_name]:
                 print(f"Warning: Overwriting existing inference time for {estimator_name} on {video_name}")
                 logging.warning(f"Overwriting existing inference time for {estimator_name} on {video_name}")
-                inference_times["total_time_per_estimator"][estimator_name] -= inference_times[estimator_name][video_name] # subtract old time from total
-                inference_times["metadata"]["total_time_taken"] -= inference_times[estimator_name][video_name] # subtract old time from total 
+                old_time = estimators[estimator_name][video_name]
+                inference_times["total_time_per_estimator"][estimator_name] -= old_time
+                inference_times["metadata"]["total_time_taken"] -= old_time
                 inference_times["videos_processed_per_estimator"][estimator_name] -= 1
 
-
-            inference_times[estimator_name][video_name] = inference_time # add new inference time
+            estimators[estimator_name][video_name] = inference_time # add new inference time
             inference_times["total_time_per_estimator"][estimator_name] += inference_time
             inference_times["metadata"]["total_time_taken"] += inference_time
             inference_times["videos_processed_per_estimator"][estimator_name] += 1
-            
+
             with open(inference_file_path, 'w') as f:
                 json.dump(inference_times, f, indent=4)
                 
@@ -216,12 +270,18 @@ class Checkpointer:
             video names to their inference times in seconds.
         """
         inference_file_path = os.path.join(self.checkpoint_dir, "inference_times.json")
-        
+
         if not os.path.exists(inference_file_path):
             print(f"No inference times found in checkpoint {self.checkpoint_dir}. Skipping inference time plot.")
             return {}
-            
+
         with open(inference_file_path, 'r') as f:
-            inference_times = json.load(f)
-            
-        return inference_times
+            try:
+                inference_times = json.load(f)
+            except json.JSONDecodeError:
+                logging.warning(f"Could not parse {inference_file_path}; returning empty inference times.")
+                return {}
+
+        # Return only the estimator -> {video: seconds} map, normalised across all
+        # on-disk shapes, so consumers (visualizer, plots) never see bookkeeping keys.
+        return estimator_timings(inference_times)

--- a/src/inference/inference_engine.py
+++ b/src/inference/inference_engine.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import logging
 import tqdm
+from progress_logging import log_progress
 
 class InferenceEngine:
     """Class responsible for running the pose estimators on the videos and saving the results in the `poses` folder."""
@@ -76,8 +77,8 @@ class InferenceEngine:
         print()
         for video in self.dataset:
             progress.update(1)
-            logging.info(progress.__str__())
-            
+            log_progress(progress.n, progress.total, f"Processing videos with {estimator.name}")
+
             if video.get_filename() in self.results[estimator.name]:
                 print(f"Skipping already processed video {video.get_filename()} for estimator {estimator.name}")
                 continue # if results already exist, skip inference

--- a/src/progress_logging.py
+++ b/src/progress_logging.py
@@ -1,0 +1,24 @@
+"""Throttled progress logging for the persistent run log.
+
+tqdm already renders a live progress bar on stderr. Writing `progress.__str__()`
+to the file log on *every* item (as the first progress-logging pass did) appends
+~one bar-string per video — tens of thousands of near-duplicate lines per run,
+plus per-iteration I/O. These helpers log only at milestones (default ~every 5%)
+and on the final item. Pure stdlib so it is unit-testable without the heavy deps.
+"""
+import logging
+
+
+def should_log_progress(done: int, total: int, every_pct: int = 5) -> bool:
+    """True at roughly every ``every_pct`` percent and on the final item."""
+    if total <= 0:
+        return True
+    step = max(1, total * every_pct // 100)
+    return done % step == 0 or done >= total
+
+
+def log_progress(done: int, total: int, label: str, every_pct: int = 5) -> None:
+    """Emit a milestone progress line to the file log (throttled)."""
+    if should_log_progress(done, total, every_pct):
+        pct = (done * 100 // total) if total else 100
+        logging.info(f"{label}: {done}/{total} ({pct}%)")

--- a/src/save_formats/npz_format.py
+++ b/src/save_formats/npz_format.py
@@ -1,6 +1,7 @@
 import logging
 
 import tqdm
+from progress_logging import log_progress
 import numpy as np
 from pathlib import Path
 from typing import Dict, List
@@ -28,7 +29,7 @@ class NpzFormat(SpecialFormat):
                 output_path = estimator_dir / f"{video_name}.npz"
                 self.save_npz(video_pose_results, output_path)
                 progress_bar.update(1)
-                logging.info(progress_bar.__str__())
+                log_progress(progress_bar.n, progress_bar.total, f"Saving NPZ for {estimator_name}")
             progress_bar.close()
             print()
 

--- a/src/scripts/raw_masked_experiment.py
+++ b/src/scripts/raw_masked_experiment.py
@@ -66,7 +66,9 @@ def run_raw_masked_experiment():
     dataset_name = "RawMaskedExperiment"
     strategies = ["Raw"] + STRATEGIES
     
-    checkpointers = {strategy: Checkpointer(dataset_name, f"{dataset_name}-{strategy}") for strategy in strategies}
+    # Load-only experiment (no inference here), so total_videos is unused -> 0.
+    # Pass it explicitly so the strategy name lands in checkpoint_name, not total_videos.
+    checkpointers = {strategy: Checkpointer(dataset_name, 0, f"{dataset_name}-{strategy}") for strategy in strategies}
     pose_results = {strategy: checkpointer.load_pose_results() for strategy, checkpointer in checkpointers.items()}
     gt_pose_results = pose_results["Raw"]
 

--- a/src/tests/inference/test_inference_times.py
+++ b/src/tests/inference/test_inference_times.py
@@ -1,0 +1,125 @@
+"""Tests for the inference_times.json schema: normalisation, migration, and the
+save/load round-trip across all three on-disk shapes (legacy-flat / mixed / nested).
+
+The mixed shape is the one written by the pre-fix `save_inference_time`; the legacy
+shape is what every real checkpoint on disk (incl. the EnvisionGestureChallenge corpus)
+currently holds. Both must read and resume without crashing or corrupting.
+"""
+import os
+import json
+import tempfile
+import unittest
+
+from checkpointer import Checkpointer, estimator_timings, migrate_inference_times
+
+EST = "MediaPipePoseWorldLandmarker"
+
+LEGACY = {EST: {"a": 1.0, "b": 2.0}}                       # flat, no bookkeeping keys
+MIXED = {                                                  # bookkeeping + estimator, no "estimators"
+    "metadata": {"total_videos": 3, "total_time_taken": 6.0},
+    EST: {"a": 1.0, "b": 2.0, "c": 3.0},
+    "videos_processed_per_estimator": {EST: 3},
+    "total_time_per_estimator": {EST: 6.0},
+}
+
+
+def _clone(d):
+    return json.loads(json.dumps(d))
+
+
+def _checkpointer(checkpoint_dir, total_videos=10):
+    """A Checkpointer that uses only checkpoint_dir + total_videos, without the
+    /output-creating __init__ (so tests stay isolated to a temp dir)."""
+    c = Checkpointer.__new__(Checkpointer)
+    c.checkpoint_dir = checkpoint_dir
+    c.total_videos = total_videos
+    return c
+
+
+class TestEstimatorTimings(unittest.TestCase):
+    def test_legacy_flat_passthrough(self):
+        self.assertEqual(estimator_timings(_clone(LEGACY)), LEGACY)
+
+    def test_mixed_strips_reserved_keys(self):
+        self.assertEqual(set(estimator_timings(_clone(MIXED)).keys()), {EST})
+
+    def test_nested_returns_submap(self):
+        nested = {"estimators": {EST: {"v": 1.0}}, "metadata": {}}
+        self.assertEqual(estimator_timings(nested), {EST: {"v": 1.0}})
+
+
+class TestMigrate(unittest.TestCase):
+    def test_legacy_recompute_rollups(self):
+        m = migrate_inference_times(_clone(LEGACY), total_videos=10)
+        self.assertEqual(m["videos_processed_per_estimator"][EST], 2)
+        self.assertAlmostEqual(m["total_time_per_estimator"][EST], 3.0)
+        self.assertEqual(set(m["estimators"].keys()), {EST})
+        self.assertEqual(m["schema_version"], 1)
+
+    def test_mixed_no_fold_in(self):
+        m = migrate_inference_times(_clone(MIXED), total_videos=3)
+        self.assertEqual(set(m["estimators"].keys()), {EST})           # not polluted
+        self.assertAlmostEqual(m["total_time_per_estimator"][EST], 6.0)  # not 6+6+3
+
+    def test_empty_is_valid(self):
+        m = migrate_inference_times({}, total_videos=5)
+        self.assertEqual(m["estimators"], {})
+        self.assertEqual(m["metadata"]["total_videos"], 5)
+
+    def test_idempotent(self):
+        m1 = migrate_inference_times(_clone(MIXED), 3)
+        m2 = migrate_inference_times(_clone(m1), 3)
+        self.assertEqual(m1["estimators"], m2["estimators"])
+        self.assertEqual(m1["total_time_per_estimator"], m2["total_time_per_estimator"])
+
+
+class TestSaveLoadRoundTrip(unittest.TestCase):
+    def _write(self, d, payload):
+        with open(os.path.join(d, "inference_times.json"), "w") as f:
+            json.dump(payload, f)
+
+    def _read(self, d):
+        with open(os.path.join(d, "inference_times.json")) as f:
+            return json.load(f)
+
+    def test_resume_legacy_checkpoint_does_not_crash(self):
+        """THE regression: saving into a pre-existing LEGACY file used to KeyError."""
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, LEGACY)
+            _checkpointer(d).save_inference_time(EST, "c", 3.0)
+            out = self._read(d)
+            self.assertEqual(out["videos_processed_per_estimator"][EST], 3)
+            self.assertAlmostEqual(out["metadata"]["total_time_taken"], 6.0)
+            self.assertEqual(out["schema_version"], 1)
+
+    def test_load_returns_clean_estimator_map_for_mixed(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, MIXED)
+            self.assertEqual(set(_checkpointer(d).load_inference_times().keys()), {EST})
+
+    def test_fresh_save_builds_current_schema(self):
+        with tempfile.TemporaryDirectory() as d:
+            _checkpointer(d, total_videos=7).save_inference_time("E", "v1", 1.5)
+            data = self._read(d)
+            self.assertEqual(data["metadata"]["total_videos"], 7)
+            self.assertEqual(data["estimators"]["E"]["v1"], 1.5)
+            self.assertEqual(data["videos_processed_per_estimator"]["E"], 1)
+
+    def test_overwrite_does_not_double_count(self):
+        with tempfile.TemporaryDirectory() as d:
+            c = _checkpointer(d)
+            c.save_inference_time("E", "v1", 1.0)
+            c.save_inference_time("E", "v1", 4.0)   # overwrite
+            data = self._read(d)
+            self.assertEqual(data["videos_processed_per_estimator"]["E"], 1)
+            self.assertAlmostEqual(data["total_time_per_estimator"]["E"], 4.0)
+
+    def test_corrupt_json_loads_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "inference_times.json"), "w") as f:
+                f.write("{ not valid json")
+            self.assertEqual(_checkpointer(d).load_inference_times(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/inference/test_inference_times.py
+++ b/src/tests/inference/test_inference_times.py
@@ -121,5 +121,25 @@ class TestSaveLoadRoundTrip(unittest.TestCase):
             self.assertEqual(_checkpointer(d).load_inference_times(), {})
 
 
+class TestCheckpointerInit(unittest.TestCase):
+    """F2: the 3-arg Checkpointer(dataset_name, total_videos, checkpoint_name) must
+    bind correctly — a string must not land in total_videos (the raw_masked_experiment bug)."""
+
+    @unittest.skipUnless(os.path.isdir("/output") and os.access("/output", os.W_OK),
+                         "needs a writable /output (container)")
+    def test_load_branch_binds_args_not_swapped(self):
+        name = "test-f2-init-tmp"
+        path = os.path.join("/output", name)
+        os.makedirs(path, exist_ok=True)
+        try:
+            c = Checkpointer("DS", 0, name)  # (dataset_name, total_videos, checkpoint_name)
+            self.assertEqual(c.total_videos, 0)
+            self.assertEqual(c.dataset_name, "DS")
+            self.assertTrue(c.checkpoint_dir.endswith(name))
+            self.assertTrue(c.load_checkpoint)
+        finally:
+            os.rmdir(path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/tests/inference/test_progress_logging.py
+++ b/src/tests/inference/test_progress_logging.py
@@ -1,0 +1,29 @@
+"""Tests for throttled progress logging (F3) — pure stdlib, no heavy deps."""
+import unittest
+
+from progress_logging import should_log_progress
+
+
+class TestProgressThrottle(unittest.TestCase):
+    def test_logs_about_every_5_percent_over_100(self):
+        logged = sum(should_log_progress(i, 100) for i in range(1, 101))
+        self.assertEqual(logged, 20)  # at 5,10,...,100 — not 100
+
+    def test_always_logs_final_item(self):
+        self.assertTrue(should_log_progress(7, 7))
+
+    def test_small_total_logs_every_item(self):
+        # total < 20 -> step == 1 -> logs every item (acceptable no-op throttle)
+        self.assertTrue(all(should_log_progress(i, 5) for i in range(1, 6)))
+
+    def test_zero_total_is_safe(self):
+        self.assertTrue(should_log_progress(0, 0))
+
+    def test_throttle_reduces_volume_at_scale(self):
+        total = 29098  # the real corpus size
+        logged = sum(should_log_progress(i, total) for i in range(1, total + 1))
+        self.assertLess(logged, total // 100)  # ~21 vs 29k
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

Fixes the `inference_times.json` schema change + progress logging from `06b8381`/`6f14949`, against an
audited plan. First concrete instance of the versioned-schema work (#153); seeds the run manifest (#154).

Full plan in this branch: `docs/inference-times-logging-fix-plan.md` (rev. 2 — adversarial audit folded in).
Commits map 1:1 to the plan's fixes for review.

## The fixes

| Commit | Fix | What & why |
|---|---|---|
| `7bfa15a` | **F1 — schema** | `inference_times.json` had **three** on-disk shapes (legacy-flat / mixed / nested). New `estimator_timings()` + `migrate_inference_times()` normalise all three on read and migrate on write. Stops two bugs: (a) `save_inference_time` **KeyError on resume** of any pre-existing checkpoint, (b) bookkeeping keys leaking into estimator iteration (visualizer/report/backend). Adds `schema_version: 1`. Guards corrupt/mid-write JSON. |
| `8f6334c` | **F2 — caller** | The 3-arg `Checkpointer(...)` signature put the strategy string into `total_videos` in `raw_masked_experiment.py` (→ new empty checkpoint instead of load). Pass `0` explicitly (load-only). |
| `7781bfe` | **F3 — logging** | `logging.info(progress.__str__())` ran every video/npz → ~29k near-duplicate bar lines per run. New pure-stdlib `progress_logging.log_progress()` logs ~every 5% + final; tqdm live bar unchanged. |

**F4** (tqdm `position=` for multi-estimator) — **deferred** (latent: single-estimator today; needs the estimator index threaded through `executor.submit`). Open for a follow-up if wanted.
**F5** (`6f14949` ffmpeg `-hide_banner -loglevel error`) — already on this branch's base; adopted unchanged.

## Verification (red → green)

- **Bug reproduced** against the *original* code: resuming a legacy checkpoint raised
  `KeyError: 'videos_processed_per_estimator'` (the real shape every checkpoint on disk has today).
- **18 tests pass** (`tests/inference/test_inference_times.py` + `test_progress_logging.py`): the 3 shapes,
  migration idempotency, the legacy-resume regression, overwrite-no-double-count, corrupt-JSON, the F2
  arg-binding, and the F3 throttle (29k → ~21 log lines).

```
Ran 18 tests in 0.013s — OK
```

## Not in this PR (correct scope)

The downstream consumers `backend/main.py` and `web/build_run_report.ps1` also read `inference_times.json`,
but they live on the UI branch, not here. They get updated to the `estimator_timings` contract in a separate
follow-up PR once this lands.

## Review notes / open decisions

- **F2 signature:** kept your positional `total_videos`; alternative is keyword-with-default (more defensive,
  changes the signature). Your call.
- **F4:** defer vs. implement now.
- **`schema_version` semantics:** introduced as `1` — confirm.
